### PR TITLE
Fix README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@
 ### 1. Cài thư viện
 ```bash
 pip install -r requirements.txt
+```
+
+### 2. Chạy
+```bash
+bash run.sh        # trên Linux/macOS
+run.bat            # trên Windows
+```
+
+Yêu cầu **Python 3.9** trở lên để đảm bảo tương thích với các thư viện.

--- a/run.bat
+++ b/run.bat
@@ -1,4 +1,4 @@
 @echo off
 echo 🔁 Đang chạy June Voice Maker...
-py june_voice_maker.py
+py JuneVoiceMaker.py
 pause

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 echo "🔁 Đang chạy June Voice Maker..."
-python3 june_voice_maker.py
+python3 JuneVoiceMaker.py


### PR DESCRIPTION
## Summary
- fix README to close code block and add instructions for running scripts

## Testing
- `python3 -m py_compile JuneVoiceMaker.py`
- `bash run.sh` *(fails: ModuleNotFoundError: No module named 'gradio')*

------
https://chatgpt.com/codex/tasks/task_e_684690c0050c832d9826b4c98de1577d